### PR TITLE
add a pyproject.toml file with build deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel", "cython", "numpy"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
this change allows building the package from a clean environment by running `pip install .`, which also allows others packages to include this one and also have a proper build with pip.